### PR TITLE
Add helpers for working with files from command-line scripts

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# Interactive Pry console started within the MB::Util context.
 
 require "bundler/setup"
 require "mb/util"

--- a/bin/prevent_overwrite_example.rb
+++ b/bin/prevent_overwrite_example.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+
+require 'fileutils'
+
+require 'mb-util'
+
+begin
+  puts "\n\n\e[1mSingle-file overwrite prompt\e[0m\n\n"
+  MB::U.prevent_overwrite($0, prompt: true)
+rescue => e
+  puts "\nReceived exception #{MB::U.highlight(e)}\n\t#{e.backtrace.join("\n\t")}"
+end
+
+begin
+  puts "\n\n\e[1mMultiple-file overwrite prompt\e[0m\n\n"
+  MB::U.prevent_mass_overwrite($0, prompt: true, delete: false)
+rescue => e
+  puts "\nReceived exception #{MB::U.highlight(e)}\n\t#{e.backtrace.join("\n\t")}"
+end

--- a/lib/mb/util.rb
+++ b/lib/mb/util.rb
@@ -1,14 +1,20 @@
 require_relative 'util/version'
+
 require_relative 'util/console_methods'
 require_relative 'util/text_methods'
 require_relative 'util/platform_methods'
+require_relative 'util/file_methods'
 
 module MB
   # General purpose utility functions, e.g. for dealing with the display.
+  #
+  # Method implementations may be found in modules under util/.  No doubt
+  # better categorization might be possible.
   module Util
     extend ConsoleMethods
     extend TextMethods
     extend PlatformMethods
+    extend FileMethods
   end
 
   # MB::U is a convenient shorthand for MB::Util.

--- a/lib/mb/util/file_methods.rb
+++ b/lib/mb/util/file_methods.rb
@@ -1,0 +1,73 @@
+module MB
+  module Util
+    # Methods useful for working with files, such as interactive prompts to
+    # prevent accidentally overwriting files.
+    #
+    # MB::Util extends itself with this module, so use these methods via
+    # MB::Util.
+    module FileMethods
+      class FileExistsError < RuntimeError
+        def initialize(filename)
+          super("File #{filename} already exists")
+        end
+      end
+
+      # Checks if +filename+ already exists.
+      #
+      # If the file exists and +:prompt+ is true, then the user is asked
+      # whether to overwrite the file.
+      #
+      # If the file exists and +:prompt+ is false, or if the user chooses not
+      # to overwrite the file, a FileExistsError is raised.
+      def prevent_overwrite(filename, prompt:)
+        if File.exist?(filename)
+          if prompt
+            STDOUT.write("\e[1;33m#{filename}\e[22m already exists.  Overwrite it?\e[0m")
+
+            if prompt_yes_no
+              STDOUT.write("\e[36mOverwriting \e[1m#{filename}\e[22m.\e[0m\n")
+              return
+            end
+          end
+
+          STDOUT.write("\e[31mNot overwriting existing file \e[1m#{filename}.\e[0m\n")
+          raise FileExistsError, filename
+        end
+      end
+
+      # Loops printing a Yes/No prompt and asking for user input until the
+      # users answers either yes or no.  Returns true if they answered starting
+      # with a Y, false if they answered starting with N.
+      #
+      # The +:color+ parameter may specify a different ANSI color for the
+      # \e[...m sequence.  For example, "34" for dark blue, "1;34" for bold
+      # blue.  See https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+      def prompt_yes_no(color: '1;33')
+        loop do
+          STDOUT.write(" \e[#{color}m[Y / N]\e[0m ")
+          STDOUT.flush
+
+          reply = STDIN.readline
+
+          case reply.downcase[0]
+          when 'y'
+            return true
+
+          when 'n'
+            return false
+          end
+        end
+      end
+
+      # Returns an Array containing the initial lines from the file that match
+      # the +:comment_regexp+, removing the first instance of +:comment_regexp+
+      # from each line, and skipping an initial shebang line ("#!...") if
+      # present.
+      def read_header_comment(filename = $0, comment_regexp: /^# /)
+        lines = File.readlines(filename)
+        lines = lines[1..-1] if lines[0] =~ /^#!/
+        lines.take_while { |l| l =~ comment_regexp }.map { |l| l.sub(comment_regexp, '') }
+      end
+    end
+  end
+end

--- a/spec/lib/mb/util/file_methods_spec.rb
+++ b/spec/lib/mb/util/file_methods_spec.rb
@@ -84,6 +84,10 @@ RSpec.describe(MB::Util::FileMethods) do
   describe '#prevent_mass_overwrite' do
     let(:glob) { 'tmp/mass_overwrite_????.test' }
 
+    before(:all) {
+      FileUtils.mkdir_p('tmp')
+    }
+
     def generate_files(initial, count)
       FileUtils.rm(Dir[glob])
       count.times do |t|

--- a/spec/lib/mb/util/file_methods_spec.rb
+++ b/spec/lib/mb/util/file_methods_spec.rb
@@ -1,0 +1,83 @@
+require 'fileutils'
+
+RSpec.describe(MB::Util::FileMethods) do
+  describe '#read_header_comment' do
+    it 'can read the header comment lines from a Ruby script' do
+      header = MB::U.read_header_comment('bin/console').join
+      expect(header).to match(/Pry/m)
+      expect(header).not_to match(/^require /m)
+    end
+  end
+
+  describe '#prevent_overwrite' do
+    let(:name) { 'tmp/prevent_overwrite_test' }
+
+    before(:all) {
+      FileUtils.mkdir_p('tmp')
+    }
+
+    context 'when prompt is true' do
+      it 'does nothing if the file does not exist' do
+        File.unlink(name) rescue nil
+
+        expect(STDIN).not_to receive(:readline)
+        expect(STDOUT).not_to receive(:write)
+
+        expect { MB::Util.prevent_overwrite(name, prompt: true) }.not_to raise_error
+      end
+
+      it 'does nothing if the user chooses to overwrite' do
+        FileUtils.touch(name)
+
+        expect(STDIN).to receive(:readline).and_return('Yo')
+        expect(STDOUT).to receive(:write).at_least(2).times
+
+        expect { MB::Util.prevent_overwrite(name, prompt: true) }.not_to raise_error
+      end
+
+      it 'raises an error if the user chooses not to overwrite' do
+        FileUtils.touch(name)
+
+        expect(STDIN).to receive(:readline).and_return('Nay')
+        expect(STDOUT).to receive(:write).at_least(2).times
+
+        expect { MB::Util.prevent_overwrite(name, prompt: true) }.to raise_error(MB::Util::FileMethods::FileExistsError)
+      end
+
+      it 'prompts until either yes or no is received' do
+        FileUtils.touch(name)
+
+        expect(STDIN).to receive(:readline).and_return('a')
+        expect(STDIN).to receive(:readline).and_return('b')
+        expect(STDIN).to receive(:readline).and_return('n')
+
+        expect(STDOUT).to receive(:write).with(/#{name}/)
+        expect(STDOUT).to receive(:write).with(/Y.*N/).exactly(3).times
+        expect(STDOUT).to receive(:write).with(/Not overwriting/)
+
+        expect { MB::Util.prevent_overwrite(name, prompt: true) }.to raise_error(MB::Util::FileMethods::FileExistsError)
+
+        expect(STDIN).to receive(:readline).and_return('y')
+
+        expect(STDOUT).to receive(:write).with(/#{name}/)
+        expect(STDOUT).to receive(:write).with(/Y.*N/)
+        expect(STDOUT).to receive(:write).with(/Overwriting/)
+
+        expect { MB::Util.prevent_overwrite(name, prompt: true) }.not_to raise_error
+      end
+    end
+
+    context 'when prompt is false' do
+      it 'does nothing if the file does not exist' do
+        File.unlink(name) rescue nil
+        expect { MB::Util.prevent_overwrite(name, prompt: false) }.not_to raise_error
+      end
+
+      it 'raises an error if the file exists' do
+        FileUtils.touch(name)
+        expect(STDOUT).to receive(:write).with(/Not overwriting/)
+        expect { MB::Util.prevent_overwrite(name, prompt: false) }.to raise_error(MB::Util::FileMethods::FileExistsError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds helpers to prompt before overwriting files and to read header comments (e.g. for printing documentation).