### PR TITLE
Handle empty inputs in the #table method

### DIFF
--- a/lib/mb/util/text_methods.rb
+++ b/lib/mb/util/text_methods.rb
@@ -168,7 +168,7 @@ module MB
 
         rows = Array(rows)
         rows = rows.map { |r| Array(r).dup }
-        columns = rows.map(&:length).max
+        columns = rows.map(&:length).max || 0
         columns = header.length if header.is_a?(Array) && header.length > columns
         rows.each { |r| r[columns - 1] = nil if r.length < columns }
 
@@ -204,11 +204,15 @@ module MB
           }
         }
 
-        column_width = formatted.map { |row|
-          row.map { |hl| MB::U.remove_ansi(hl).length + 2 }
-        }.transpose.map.with_index { |col, idx|
-          [col.max, header_width[idx] || 0].max
-        }
+        if formatted.empty?
+          column_width = header_width.dup
+        else
+          column_width = formatted.map { |row|
+            row.map { |hl| MB::U.remove_ansi(hl).length + 2 }
+          }.transpose.map.with_index { |col, idx|
+            [col.max, header_width[idx] || 0].max
+          }
+        end
 
         column_width = [column_width.max] * column_width.length unless variable_width
         total_width = column_width.sum + column_width.length - 1

--- a/spec/lib/mb/util/text_methods_spec.rb
+++ b/spec/lib/mb/util/text_methods_spec.rb
@@ -1,3 +1,5 @@
+require 'timeout'
+
 RSpec.describe(MB::Util::TextMethods) do
   describe '#highlight' do
     it 'includes some ANSI colors when given a Hash' do
@@ -104,6 +106,30 @@ RSpec.describe(MB::Util::TextMethods) do
   end
 
   describe '#table' do
+    context 'with empty inputs' do
+      it 'does not loop forever if given an empty Array' do
+        expect {
+          Timeout.timeout(5) do
+            MB::U.table([])
+          end
+        }.not_to raise_error
+      end
+
+      it 'does not loop forever if given an empty Hash' do
+        expect {
+          Timeout.timeout(5) do
+            MB::U.table({})
+          end
+        }.not_to raise_error
+      end
+
+      it 'can display a Hash with empty columns' do
+        expect(MB::Util).to receive(:puts).with(/[^ |]* [^ |]*1[^ |]* [^ |*]/)
+        expect(MB::Util).to receive(:puts).with(/---/)
+        MB::U.table({1 => []})
+      end
+    end
+
     it 'can use a short String as the header' do
       expect(MB::Util).to receive(:puts).with("   \e[1mTest\e[0m    ")
       expect(MB::Util).to receive(:puts).with('---+---+---')

--- a/spec/lib/mb/util/text_methods_spec.rb
+++ b/spec/lib/mb/util/text_methods_spec.rb
@@ -108,6 +108,9 @@ RSpec.describe(MB::Util::TextMethods) do
   describe '#table' do
     context 'with empty inputs' do
       it 'does not loop forever if given an empty Array' do
+        expect(MB::U).to receive(:puts).with('')
+        expect(MB::U).to receive(:puts).with('')
+
         expect {
           Timeout.timeout(5) do
             MB::U.table([])
@@ -116,6 +119,9 @@ RSpec.describe(MB::Util::TextMethods) do
       end
 
       it 'does not loop forever if given an empty Hash' do
+        expect(MB::U).to receive(:puts).with('')
+        expect(MB::U).to receive(:puts).with('')
+
         expect {
           Timeout.timeout(5) do
             MB::U.table({})
@@ -125,7 +131,7 @@ RSpec.describe(MB::Util::TextMethods) do
 
       it 'can display a Hash with empty columns' do
         expect(MB::Util).to receive(:puts).with(/[^ |]* [^ |]*1[^ |]* [^ |*]/)
-        expect(MB::Util).to receive(:puts).with(/---/)
+        expect(MB::Util).to receive(:puts).with('---')
         MB::U.table({1 => []})
       end
     end


### PR DESCRIPTION
`TextUtils#table` was looping infinitely if given an empty Array, and raising an exception if given an empty Hash.  This PR fixes those errors and adds tests that verify the fix.