### PR TITLE
Fix traces from Timeout::Error, remove trailing newlines from highlight

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mb-util (0.1.11.usegit)
+    mb-util (0.1.12.usegit)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/mb/util/text_methods.rb
+++ b/lib/mb/util/text_methods.rb
@@ -55,7 +55,7 @@ module MB
           color_trace(object)
         else
           require 'pry'
-          Pry::ColorPrinter.pp(object, '', columns || width)
+          Pry::ColorPrinter.pp(object, '', columns || width).strip!
         end
       rescue LoadError
         Kernel.warn 'Failed to load Pry for pretty-printing'

--- a/lib/mb/util/version.rb
+++ b/lib/mb/util/version.rb
@@ -1,5 +1,5 @@
 module MB
   module Util
-    VERSION = "0.1.11.usegit"
+    VERSION = "0.1.12.usegit"
   end
 end

--- a/spec/lib/mb/util/text_methods_spec.rb
+++ b/spec/lib/mb/util/text_methods_spec.rb
@@ -21,8 +21,18 @@ RSpec.describe(MB::Util::TextMethods) do
 
   describe '#color_trace' do
     it 'raises an error if given invalid types' do
-      expect { MB::U.color_trace(['invalid array']) }.to raise_error(MB::Util::TextMethods::TraceArgumentError)
+      expect { MB::U.color_trace([:invalid_array]) }.to raise_error(MB::Util::TextMethods::TraceArgumentError)
       expect { MB::U.color_trace('invalid arg') }.to raise_error(MB::Util::TextMethods::TraceArgumentError)
+    end
+
+    it 'formats arrays of strings' do
+      trace = [
+        "/foo/bar/baz/blah.rb:12345:in `location'",
+        "(pry):0:in `there'",
+      ]
+      result = MB::U.color_trace(trace)
+      expect(result).to include("\e[0m")
+      expect(MB::U.remove_ansi(result)).to eq(trace.join("\n"))
     end
 
     it 'formats caller locations' do

--- a/spec/lib/mb/util/text_methods_spec.rb
+++ b/spec/lib/mb/util/text_methods_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe(MB::Util::TextMethods) do
       text = MB::Util.highlight(RuntimeError.new)
       expect(text).to eq('test here')
     end
+
+    it 'does not end with a newline when given lots of data' do
+      result = MB::Util.highlight((1..1000).to_a)
+      expect(result).to include("\n")
+      expect(result).not_to end_with("\n")
+    end
   end
 
   describe '#color_trace' do


### PR DESCRIPTION
Timeout::Error returns nil for `#backtrace_locations`, so `#backtrace` is used as a fallback if `#backtrace_locations` is nil, and support was added for colorizing backtrace Strings as well as Thread::Backtrace::Location objects.  Fixes #5.

Additionally, trailing newlines were removed from Pry-generated highlighted output.  Fixes #6.